### PR TITLE
:wrench: fix cd-ncloud.yml config

### DIFF
--- a/.github/workflows/cd-ncloud.yml
+++ b/.github/workflows/cd-ncloud.yml
@@ -17,5 +17,5 @@ jobs:
           password: ${{ secrets.NCP_DEV_SERVER_PASSWORD }}
           port: ${{ secrets.NCP_DEV_SERVER_PORT }}
           script: |
-            ssh was
+            ssh -t was
             bash deploy.sh


### PR DESCRIPTION
원격 ssh 서버 접속시 파이프 라인 명령어가 문제가 될 수 있다는 글을 찾았다.
-t 옵션을 붙여줬다.