### PR TITLE
:wrench: fix cd-ncloud.yml config

### DIFF
--- a/.github/workflows/cd-ncloud.yml
+++ b/.github/workflows/cd-ncloud.yml
@@ -18,4 +18,4 @@ jobs:
           port: ${{ secrets.NCP_DEV_SERVER_PORT }}
           script: |
             ssh -T was
-            bash deploy.sh
+            bash /root/deploy.sh


### PR DESCRIPTION
-T 옵션이 문제가 아니었다. 이건 그냥 경고였고 was server까지 접근을 잘했다.
혹시 경로를 제대로 입력하지 않아서 그런것 같아서 경로를 입력해봤다.