### PR TITLE
:wrench: fix cd-ncloud.yml config

### DIFF
--- a/.github/workflows/cd-ncloud.yml
+++ b/.github/workflows/cd-ncloud.yml
@@ -17,7 +17,4 @@ jobs:
           password: ${{ secrets.NCP_DEV_SERVER_PASSWORD }}
           port: ${{ secrets.NCP_DEV_SERVER_PORT }}
           script: |
-            ssh -T was
-            pwd
-            ls
-            ifconfig
+            bash /root/deploy.sh main local


### PR DESCRIPTION
결국 GitHub Action을 이용해서 Bastion Server를 거쳐 Was Server로 접근해 명령어를 실행하는 방법을 찾지 못했다..

외부 SSH 연결 IP를 WAS로 변경했다. 계속 방법을 생각해봐야겠다.